### PR TITLE
Fix: Update grid when stop equals start

### DIFF
--- a/cfmining/action_set.py
+++ b/cfmining/action_set.py
@@ -413,6 +413,9 @@ class _ActionElement(object):
         stop = self.ub
         step = self.step_size
 
+        if stop - start == 0:
+            return
+
         if self._variable_type == int:
             start = np.floor(self.lb)
             stop = np.ceil(self.ub)


### PR DESCRIPTION
This PR fixes a minor issue regarding action set. If `start` and `stop` are equal we can't use `np.arange`, since their difference is `0`, leading to an error while generating the `ActionSet`

We fixed this by adding an early return to that method.